### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve
+---
+<!--- Verify first that your issue is not already reported on GitHub -->
+<!--- Also test if the latest release and devel branch are affected too -->
+<!--- Complete *all* sections as described -->
+
+#### Summary
+<!--- Describe briefly your problem. -->
+
+
+#### Issue Type
+- Bug Report
+
+#### Steps to reproduce
+<!--- Provide a way to reproduce this bug. Include code to reproduce, if relevant. -->
+
+
+#### Actual results
+<!--- Describe in detail the actual behavior -->
+
+
+#### Expected results
+<!--- Describe what should be the expected behavior. -->
+
+
+#### OS / Environment
+<!--- Provide all relevant information, e.g. target OS, python and library version, etc. -->
+
+
+#### Additional Information
+<!--- Include any relevant information that does not fit in other items, e.g. stack trace, logs, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: ✨ Feature request
+about: Suggest an idea for this project
+---
+<!--- Verify first that your feature was not already discussed on GitHub -->
+<!--- Complete *all* sections as described -->
+
+#### Summary
+<!--- Describe briefly your request. -->
+
+
+#### Issue Type
+- Feature Request
+
+#### Current behavior
+<!--- Describe in detail the actual behavior, if applicable. -->
+
+
+#### Desired behavior
+<!--- Describe what should be the expected behavior, if applicable. -->
+
+
+#### Use case
+<!--- Describe a use case for this feature, why it is needed and what it solves. -->
+
+
+#### Additional Information
+<!--- Include any relevant information that does not fit in other items, e.g. logs, code samples, etc. -->

--- a/.github/ISSUE_TEMPLATE/question_support.md
+++ b/.github/ISSUE_TEMPLATE/question_support.md
@@ -1,0 +1,16 @@
+---
+name: 🙋 Question / Support
+about: Raise questions related to this project
+---
+<!--- Verify first that your question was not already discussed on GitHub -->
+<!--- Complete *all* sections as described -->
+
+#### Summary
+<!--- Describe in detail your question. -->
+
+
+#### Issue Type
+- Question / Support
+
+#### Additional Information
+<!--- Include any relevant information that could help to answer your question, e.g. OS version, logs, etc. -->


### PR DESCRIPTION
This commit implements issue templates to give Github issue reports
three distinct categories each with appropriately structured bodies.

Fixes #3