### PR TITLE
Make deployment cleaner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# deployment package
+package.zip
+package/

--- a/cdn_lambda/__init__.py
+++ b/cdn_lambda/__init__.py
@@ -1,0 +1,8 @@
+from cdn_lambda.functions.map_to_s3.map_to_s3 import (
+    lambda_handler as origin_request,
+)
+
+# All lambda functions should be exported from this module.
+# Name them after the trigger with which they're intended to be used.
+
+__all__ = ["origin_request"]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,7 @@
+from cdn_lambda import origin_request
+
+
+def test_have_origin_request():
+    """cdn_lambda should export a function named origin_request"""
+
+    assert callable(origin_request)

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,27 @@ deps=
 commands=pytest {posargs}
 whitelist_externals=sh
 
+# Create a lambda deployment package.
+[testenv:package]
+skip_install=true
+deps=
+whitelist_externals=
+    sh
+    rm
+    cp
+commands=
+    rm -rf ./package
+
+    # --no-deps to avoid using anything untrusted from PyPI;
+    # currently all deps are expected to be available from lambda runtime anyway.
+    pip install --no-deps --target ./package .
+
+    # Always using hardcoded config for now.
+    cp cdn_lambda/functions/map_to_s3/map_to_s3.json package
+
+    sh -c 'cd package && zip -r ../package.zip .'
+    rm -rf ./package
+
 [testenv:static]
 deps=
 	-rtest-requirements.txt


### PR DESCRIPTION
- Add a tox configuration for creating a deployment zip file, so there's a
  standard way of doing it
- Add top-level export for lambda function, so that internal module structure
  doesn't influence AWS configs

See individual commits for more details.