### PR TITLE
Provide origin path aliases for map_to_s3 [DELIVERY-9004]

### DIFF
--- a/cdn_lambda/functions/map_to_s3/map_to_s3.json
+++ b/cdn_lambda/functions/map_to_s3/map_to_s3.json
@@ -2,5 +2,9 @@
   "table": {
     "name": "exodus",
     "region": "us-east-1"
-  }
+  },
+  "uri_aliases": [
+    ["/content/origin/", "/origin/"],
+    ["/origin/rpm/", "/origin/rpms/"]
+  ]
 }


### PR DESCRIPTION
This commit adds path alias mapping in map_to_s3 configuration file and
a method in the function itself to transform URIs. If the beginning of a
URI matches a key specified in the configuration file, it is replaced by
the key's value.